### PR TITLE
Add wrist camera to gazebo

### DIFF
--- a/aurmr_gazebo/robots/tahoma.gazebo.xacro
+++ b/aurmr_gazebo/robots/tahoma.gazebo.xacro
@@ -144,6 +144,7 @@
   <xacro:if value="${'$(arg realsense)' == 'true' }">
     <xacro:sensor_l515_gazebo name="camera_lower_left"/>
     <xacro:sensor_l515_gazebo name="camera_lower_right"/>
+    <xacro:sensor_l515_gazebo name="camera_wrist"/>
   </xacro:if>
 
 </robot>


### PR DESCRIPTION
I added the camera to tahoma.gazebo.xacro so it is simulated.

I also had to modify aurmr_tahoma (see this PR: https://github.com/au-rmr/aurmr_tahoma/pull/1)